### PR TITLE
[ADD] method for search in one index

### DIFF
--- a/lib/elasticsearch_rasi/base.rb
+++ b/lib/elasticsearch_rasi/base.rb
@@ -135,5 +135,14 @@ class ElasticsearchRasi
         body:  query)
       response['hits']['total'].to_i || 0
     end
+
+    def query_search_one_index(query, idx, type = 'document')
+      response = request(
+          :search,
+          index: idx,
+          type: type,
+          body: query) || (return {})
+      parse_response(response)
+    end
   end
 end

--- a/lib/elasticsearch_rasi/document.rb
+++ b/lib/elasticsearch_rasi/document.rb
@@ -113,6 +113,10 @@ class ElasticsearchRasi
       query_search(query, idx, type)
     end
 
+    def search_in_index(query, idx = @config[:idx_read], type = @config[:type])
+      query_search_one_index(query, idx, type)
+    end
+
   private
 
     # for data moving between elastics, we need to keep recognizing index based on published_at

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -6,7 +6,7 @@ require 'elasticsearch_rasi'
 describe ElasticsearchRasi do
   context 'methods' do
     before(:context) do
-      @rasi_es = ElasticsearchRasi.new(:disputatio)
+      @rasi_es = ElasticsearchRasi.new(:disputatio, {:url => 'localhost:9200', :host => 'localhost:9200', :connect => {:host => 'localhost:9200'}})
     end
 
     context 'prepare_search_author' do
@@ -28,6 +28,27 @@ describe ElasticsearchRasi do
 
         it 'wrong query' do
           expect { response }.to raise_error(ParseResponseError)
+        end
+      end
+    end
+
+    describe 'search_in_index' do
+
+      context 'right index is given' do
+        let(:response) do
+          @rasi_es.node.search_in_index({}, 'disputatio_articles', 'document')
+        end
+        it 'response is valid' do
+          expect{ response }.equal? 10
+        end
+      end
+
+      context 'wrong index is given' do
+        let(:response) do
+          @rasi_es.node.search_in_index({}, 'blbost', 'document')
+        end
+        it 'searching raise error' do
+          expect{ response }.to raise_error()
         end
       end
     end


### PR DESCRIPTION
U některých příspěvků (např. u zdroje aaaauto-cz) nejsou odkazy na jednotlivé příspěvky a ani u nich není čas zveřejnění. Příspěvky se tedy stáhnout do jednou do jednoho indexu a podruhé, když se vytvoří index nový, tak do toho dalšího indexu - jsou tedy duplikované. Hodila by se metoda, která by zkontrolovala, jestli už v celém aliasu není příspěvek se stejným id. Co myslíš? 